### PR TITLE
Added a way to use always the same jar

### DIFF
--- a/src/main/java/com/songoda/serverjars/Config.java
+++ b/src/main/java/com/songoda/serverjars/Config.java
@@ -14,6 +14,7 @@ public class Config {
 
     private static final String DEFAULT_TYPE = "paper";
     private static final String DEFAULT_VERSION = "latest";
+    private static final boolean DEFAULT_USE_HOME = false;
 
     private final Properties properties;
     private final File file;
@@ -39,6 +40,14 @@ public class Config {
 
     String getVersion() {
         return this.properties.getProperty("version", DEFAULT_VERSION);
+    }
+
+    void setUseHome(boolean home) {
+        this.properties.setProperty("useSameJar", String.valueOf(home));
+    }
+
+    boolean getUseHome() {
+        return this.properties.getProperty("useSameJar", String.valueOf(DEFAULT_USE_HOME)).equals("true");
     }
 
     void setLastUpdateCheck(long timestamp) {

--- a/src/main/java/com/songoda/serverjars/ServerJars.java
+++ b/src/main/java/com/songoda/serverjars/ServerJars.java
@@ -160,7 +160,7 @@ public final class ServerJars {
 
                 version = chosenVersion;
 
-                System.out.println("\nWould you like to use the always the same server jar for every ServerJars instance? [Y/N]");
+                System.out.println("\nWould you like to use always the same server jar for every ServerJars instance? [Y/N]");
                 String alwaysUse = awaitInput(s -> s.equalsIgnoreCase("y") || s.equalsIgnoreCase("n"), "Please choose Y or N");
 
                 if (alwaysUse == null || alwaysUse.equalsIgnoreCase("y")) {

--- a/src/main/java/com/songoda/serverjars/ServerJars.java
+++ b/src/main/java/com/songoda/serverjars/ServerJars.java
@@ -27,7 +27,7 @@ import java.util.function.Predicate;
 public final class ServerJars {
     private static final File WORKING_DIRECTORY = new File(".");
     private static final File CFG_FILE = new File(WORKING_DIRECTORY, "serverjars.properties");
-    private static final File CACHE_DIR = new File(WORKING_DIRECTORY, "jar");
+    private static File CACHE_DIR;
 
     private static final Config cfg = new Config(CFG_FILE);
 
@@ -159,6 +159,16 @@ public final class ServerJars {
                 }
 
                 version = chosenVersion;
+
+                System.out.println("\nWould you like to use the always the same server jar for every ServerJars instance? [Y/N]");
+                String alwaysUse = awaitInput(s -> s.equalsIgnoreCase("y") || s.equalsIgnoreCase("n"), "Please choose Y or N");
+
+                if (alwaysUse == null || alwaysUse.equalsIgnoreCase("y")) {
+                    cfg.setUseHome(true);
+                } else {
+                    cfg.setUseHome(false);
+                }
+
                 System.out.println("Setup completed!\n");
                 cfg.setType(type);
                 cfg.setVersion(version);
@@ -186,6 +196,7 @@ public final class ServerJars {
             }
         }
 
+        CACHE_DIR = cfg.getUseHome() ? new File(System.getProperty("user.home"), ".serverjars") : new File(WORKING_DIRECTORY, "jar");
         Files.createDirectories(CACHE_DIR.toPath());
         File jar = new File(CACHE_DIR, jarDetails.getFile());
 


### PR DESCRIPTION
Hello, I'm a developer and I always use ServerJars to test my plugins. Every time I start a server for testing a plugin the updater will download the new jar. With this option I can always use the same server jar for every server instance. I think it will be very usefull for lots of users.