### PR TITLE
Disables the Automatically change profile version action that fails for various reasons

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="zulu-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectType">
+    <option name="id" value="jpab" />
+  </component>
 </project>

--- a/src/main/java/com/songoda/serverjars/ServerJars.java
+++ b/src/main/java/com/songoda/serverjars/ServerJars.java
@@ -232,7 +232,7 @@ public final class ServerJars {
         if(jarDetails == null) {
             if(!version.equals("latest")){ // Only show the error message if is not the latest version what we're looking for.
                 System.out.println("Could not fetch jar details for the given version '" + version + "'. Using latest...");
-                config.setVersion("latest");
+//                config.setVersion("latest");
                 try {
                     config.save();
                     return setupEnv(false);


### PR DESCRIPTION
According to what I found during my use:
When the network is poor or the connection fails for a short period of time, it is very easy for the version number to be automatically changed to latest, causing the server to be upgraded to the latest version inexplicably, resulting in damage to the server database.
Therefore, in this update, I disabled the action of automatically changing the version number under certain conditions.